### PR TITLE
fix(db): re-raise errors in session context

### DIFF
--- a/collector/src/db/database.py
+++ b/collector/src/db/database.py
@@ -30,5 +30,6 @@ class DataBase:
             await session.rollback()
             logger.warning("got error in session context. rollback changes.")
             logger.error(e)
+            raise
         finally:
             await session.aclose()

--- a/collector/tests/db/test_database.py
+++ b/collector/tests/db/test_database.py
@@ -27,15 +27,13 @@ async def test_session_rollback_on_exception(db: DataBase):
         )
 
     # Пытаемся добавить запись и вызвать ошибку
-    try:
+    with pytest.raises(CustomError):
         async with db.session() as session:
             await session.execute(text("INSERT INTO items (name) VALUES ('test')"))
             result = await session.execute(text("SELECT COUNT(*) FROM items"))
             count_before = result.scalar()
             assert count_before == 1  # запись добавлена
             raise CustomError("Force rollback")
-    except CustomError:
-        pass
 
     # Проверяем, что после rollback в таблице пусто
     async with db.session() as session:


### PR DESCRIPTION
## Summary
- re-raise exceptions from database session context after logging
- test session context exception propagation and rollback

## Testing
- `cd collector && uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3663bbdb48325ab6eff18cbd6c8a3