### PR TITLE
fix: correct Twitch connection log

### DIFF
--- a/collector/src/infra/twitch/twitch_client.py
+++ b/collector/src/infra/twitch/twitch_client.py
@@ -31,5 +31,5 @@ class TwichClient:
     async def _on_ready(self, ready_event: EventData) -> None:
         logger.debug("Bot is ready for work, joining channels")
         await ready_event.chat.join_room(self.targets)
-        logger.debug(f"Connected as: ${ready_event.chat.username}")
+        logger.debug(f"Connected as: {ready_event.chat.username}")
         logger.info(f"joined to [bold magenta]{self.targets}[/]")

--- a/collector/tests/infra/twitch/test_twitch_client.py
+++ b/collector/tests/infra/twitch/test_twitch_client.py
@@ -1,0 +1,30 @@
+import pytest
+from loguru import logger
+
+from infra.twitch.twitch_client import TwichClient
+
+
+class DummyChat:
+    username = "dummy_user"
+
+    async def join_room(self, channels: str) -> None:
+        self.joined = channels
+
+
+class DummyReadyEvent:
+    def __init__(self) -> None:
+        self.chat = DummyChat()
+
+
+@pytest.mark.asyncio
+async def test_on_ready_logs_connected_message(caplog):
+    client = object.__new__(TwichClient)
+    client.targets = "#test"
+    event = DummyReadyEvent()
+
+    with caplog.at_level("DEBUG"):
+        handler_id = logger.add(caplog.handler, level="DEBUG")
+        await TwichClient._on_ready(client, event)
+        logger.remove(handler_id)
+
+    assert f"Connected as: {event.chat.username}" in caplog.text


### PR DESCRIPTION
## Summary
- fix Twitch connection log format
- test Twitch client ready event logging

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3663bc4108325883002826ad37113