### PR TITLE
fix(twitch): update on_ready handler to use EventData

### DIFF
--- a/collector/src/infra/twitch/twitch_client.py
+++ b/collector/src/infra/twitch/twitch_client.py
@@ -17,7 +17,7 @@ class TwichClient:
         self.chat.register_event(ChatEvent.MESSAGE, handler)
 
     def add_on_ready_handler(
-        self, handler: Callable[[ChatMessage], Awaitable[None]]
+        self, handler: Callable[[EventData], Awaitable[None]]
     ) -> None:
         self.chat.register_event(ChatEvent.READY, handler)
 


### PR DESCRIPTION
## Summary
- fix on_ready handler annotation to use EventData instead of ChatMessage

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3663e4d1c83258021889418c1f2cd