### PR TITLE
fix: use running event loop for Twitch source

### DIFF
--- a/collector/src/infra/source/twitch.py
+++ b/collector/src/infra/source/twitch.py
@@ -16,7 +16,7 @@ from logic.messages.source import MessageSource
 class TwitchMessageSource(MessageSource):
     def __init__(self, twitch_client: TwichClient) -> None:
         self._queue: Queue[ChatMessage] = Queue()
-        self._main_loop = asyncio.get_event_loop()
+        self._main_loop = asyncio.get_running_loop()
 
         twitch_client.add_message_handler(self.on_message)
 

--- a/collector/tests/config/test_container.py
+++ b/collector/tests/config/test_container.py
@@ -1,5 +1,5 @@
 # type: ignore
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from dependency_injector.providers import Resource, Singleton
@@ -26,8 +26,10 @@ def test_settings() -> Settings:
     )
 
 
+@patch("asyncio.get_running_loop")
 @pytest.mark.asyncio
-async def test_container_basic_init(test_settings: Settings):
+async def test_container_basic_init(mock_get_running_loop, test_settings: Settings):
+    mock_get_running_loop.return_value = MagicMock()
     container = Container()
 
     # Override settings with test settings
@@ -45,6 +47,7 @@ async def test_container_basic_init(test_settings: Settings):
     # Test singleton providers can be created and injected correctly
     message_source = container.message_source()
     assert message_source is not None
+    mock_get_running_loop.assert_called_once()
 
     name_filter = container.name_filter()
     assert name_filter is not None


### PR DESCRIPTION
## Summary
- ensure TwitchMessageSource uses the running asyncio loop
- mock asyncio.get_running_loop in container tests

## Testing
- `PYTHONPATH=collector/src uv run --with pydantic --with dependency-injector --with sqlalchemy --with loguru --with faker pytest` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68bd24c0aafc8325b8d62ccc96b26e5b